### PR TITLE
explorer ui server node modules encoding fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ Thumbs.db
 dockerfiles/*/build_and_start_vlcvi01.sh
 dockerfiles/zowe-1.7.1/.vscode/settings.json
 dockerfiles/*/build_and_run_vlcvi01.sh
+dockerfiles/zowe-release/amd64/zowe-v1-lts/utils
 
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/dockerfiles/zowe-release/amd64/zowe-v1-lts/Dockerfile
+++ b/dockerfiles/zowe-release/amd64/zowe-v1-lts/Dockerfile
@@ -79,6 +79,10 @@ RUN rm -f /root/zowe/*.pax && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* 
 
+RUN cd /root/zowe/install/shared/explorer-ui-server && \
+    rm -rf node_modules && \
+    npm install --only=prod --ignore-scripts
+
 COPY run.sh /root/zowe/
 # Could be modified during runtime, back it up.
 RUN cp /root/zowe/instance/instance.env /root/zowe/instance/instance.env.bkp

--- a/dockerfiles/zowe-release/amd64/zowe-v1-lts/Dockerfile.jenkins
+++ b/dockerfiles/zowe-release/amd64/zowe-v1-lts/Dockerfile.jenkins
@@ -80,6 +80,10 @@ RUN rm -f /root/zowe/*.pax && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* 
 
+RUN cd /root/zowe/install/shared/explorer-ui-server && \
+    rm -rf node_modules && \
+    npm install --only=prod --ignore-scripts
+    
 COPY run.sh /root/zowe/
 # Could be modified during runtime, back it up.
 RUN cp /root/zowe/instance/instance.env /root/zowe/instance/instance.env.bkp

--- a/dockerfiles/zowe-release/amd64/zowe-v1-lts/README.md
+++ b/dockerfiles/zowe-release/amd64/zowe-v1-lts/README.md
@@ -7,7 +7,7 @@
 
 **TL;DR**:
 ```sh
-docker pull rsqa/zowe-v1-lts:amd64
+docker pull ompzowe/zowe-v1-lts:amd64
 export DISCOVERY_PORT=7553
 export GATEWAY_PORT=7554
 export APP_SERVER_PORT=8544
@@ -32,7 +32,7 @@ docker run -it \
     --env DISCOVERY_PORT=${DISCOVERY_PORT} \
     --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} \
     --mount type=bind,source=c:\temp\certs,target=/root/zowe/certs \
-    rsqa/zowe-v1-lts:amd64
+    ompzowe/zowe-v1-lts:amd64
 ```
 Open browser and test it
  - API Mediation Layer: https://myhost.acme.net:7554
@@ -80,7 +80,7 @@ docker build -t zowe/docker:latest .
 For example:
 
 ```cmd
-DISCOVERY_PORT=7553 GATEWAY_PORT=7554 APP_SERVER_PORT=8544 docker run -it -h your_hostname --env ZOWE_IP_ADDRESS=your.external.ip --env LAUNCH_COMPONENT_GROUPS=DESKTOP,GATEWAY --env ZOSMF_HOST=your.zosmainframe.com --env ZWED_agent_host=your.zosmainframe.com --env ZOSMF_PORT=11443 --env ZWED_agent_http_port=8542 --expose ${DISCOVERY_PORT} --expose ${GATEWAY_PORT} --expose ${APP_SERVER_PORT} -p ${DISCOVERY_PORT}:${DISCOVERY_PORT} -p ${GATEWAY_PORT}:${GATEWAY_PORT} -p ${APP_SERVER_PORT}:${APP_SERVER_PORT} --env GATEWAY_PORT=${GATEWAY_PORT} --env DISCOVERY_PORT=${DISCOVERY_PORT} --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} --env EXTERNAL_CERTIFICATE=/root/zowe/ext_certs/my.keystore.p12 --env EXTERNAL_CERTIFICATE_ALIAS=alias --env EXTERNAL_CERTIFICATE_AUTHORITIES=/root/zowe/ext_certs/myCA.cer --mount type=bind,source=<folder with certs>,target=/root/zowe/ext_certs rsqa/zowe-v1-lts:amd64
+DISCOVERY_PORT=7553 GATEWAY_PORT=7554 APP_SERVER_PORT=8544 docker run -it -h your_hostname --env ZOWE_IP_ADDRESS=your.external.ip --env LAUNCH_COMPONENT_GROUPS=DESKTOP,GATEWAY --env ZOSMF_HOST=your.zosmainframe.com --env ZWED_agent_host=your.zosmainframe.com --env ZOSMF_PORT=11443 --env ZWED_agent_http_port=8542 --expose ${DISCOVERY_PORT} --expose ${GATEWAY_PORT} --expose ${APP_SERVER_PORT} -p ${DISCOVERY_PORT}:${DISCOVERY_PORT} -p ${GATEWAY_PORT}:${GATEWAY_PORT} -p ${APP_SERVER_PORT}:${APP_SERVER_PORT} --env GATEWAY_PORT=${GATEWAY_PORT} --env DISCOVERY_PORT=${DISCOVERY_PORT} --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} --env EXTERNAL_CERTIFICATE=/root/zowe/ext_certs/my.keystore.p12 --env EXTERNAL_CERTIFICATE_ALIAS=alias --env EXTERNAL_CERTIFICATE_AUTHORITIES=/root/zowe/ext_certs/myCA.cer --mount type=bind,source=<folder with certs>,target=/root/zowe/ext_certs ompzowe/zowe-v1-lts:amd64
 ```
 Note: External certificates are optional and should not be included in the start command if undesired.
 
@@ -136,7 +136,7 @@ docker run -it ^
     --env DISCOVERY_PORT=%DISCOVERY_PORT% ^
     --env ZOWE_ZLUX_SERVER_HTTPS_PORT=%APP_SERVER_PORT% ^
     --mount type=bind,c:\workspaces\ZooTainers-Hackathon2019\certs,target=/root/zowe/certs ^
-    rsqa/zowe-v1-lts:amd64
+    ompzowe/zowe-v1-lts:amd64
 ```
 
 ### Linux
@@ -163,7 +163,7 @@ docker run -it \
     --env DISCOVERY_PORT=${DISCOVERY_PORT} \
     --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} \
     --mount type=bind,source=c:\temp\certs,target=/root/zowe/certs \
-    rsqa/zowe-v1-lts:amd64
+    ompzowe/zowe-v1-lts:amd64
 ```
 
 #### Expected output
@@ -211,7 +211,7 @@ docker run -it \
     --env DISCOVERY_PORT=${DISCOVERY_PORT} \
     --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} \
 	-v ~/apps:/root/zowe/apps:rw \
-    rsqa/zowe-v1-lts:amd64 $@
+    ompzowe/zowe-v1-lts:amd64 $@
 ```
 
 By default, external plugins in the ```/root/zowe/apps``` folder will be installed at start up.

--- a/dockerfiles/zowe-release/amd64/zowe-v1-lts/build.sh
+++ b/dockerfiles/zowe-release/amd64/zowe-v1-lts/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mkdir utils
 cp -r ../../../../utils/* ./utils
-docker build -f Dockerfile --no-cache -t rsqa/zowe-v1-lts:testing$1 .
+docker build -f Dockerfile --no-cache -t ompzowe/zowe-v1-lts:testing$1 .

--- a/dockerfiles/zowe-release/s390x/zowe-v1-lts/Dockerfile
+++ b/dockerfiles/zowe-release/s390x/zowe-v1-lts/Dockerfile
@@ -85,6 +85,10 @@ RUN rm -f /root/zowe/*.pax && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* 
 
+RUN cd /root/zowe/install/shared/explorer-ui-server && \
+    rm -rf node_modules && \
+    npm install --only=prod --ignore-scripts
+
 COPY run.sh /root/zowe/
 # Could be modified during runtime, back it up.
 RUN cp /root/zowe/instance/instance.env /root/zowe/instance/instance.env.bkp

--- a/dockerfiles/zowe-release/s390x/zowe-v1-lts/Dockerfile.jenkins
+++ b/dockerfiles/zowe-release/s390x/zowe-v1-lts/Dockerfile.jenkins
@@ -85,6 +85,10 @@ RUN rm -f /root/zowe/*.pax && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* 
 
+RUN cd /root/zowe/install/shared/explorer-ui-server && \
+    rm -rf node_modules && \
+    npm install --only=prod --ignore-scripts
+
 COPY run.sh /root/zowe/
 # Could be modified during runtime, back it up.
 RUN cp /root/zowe/instance/instance.env /root/zowe/instance/instance.env.bkp

--- a/dockerfiles/zowe-release/s390x/zowe-v1-lts/README.md
+++ b/dockerfiles/zowe-release/s390x/zowe-v1-lts/README.md
@@ -7,7 +7,7 @@
 
 **TL;DR**:
 ```sh
-docker pull rsqa/zowe-v1-lts:s390x
+docker pull ompzowe/zowe-v1-lts:s390x
 export DISCOVERY_PORT=7553
 export GATEWAY_PORT=7554
 export APP_SERVER_PORT=8544
@@ -32,7 +32,7 @@ docker run -it \
     --env DISCOVERY_PORT=${DISCOVERY_PORT} \
     --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} \
     --mount type=bind,source=c:\temp\certs,target=/root/zowe/certs \
-    rsqa/zowe-v1-lts:s390x
+    ompzowe/zowe-v1-lts:s390x
 ```
 Open browser and test it
  - API Mediation Layer: https://myhost.acme.net:7554
@@ -70,7 +70,7 @@ docker build -t zowe/docker:latest .
 For example:
 
 ```cmd
-DISCOVERY_PORT=7553 GATEWAY_PORT=7554 APP_SERVER_PORT=8544 docker run -it -h your_hostname --env ZOWE_IP_ADDRESS=your.external.ip --env LAUNCH_COMPONENT_GROUPS=DESKTOP,GATEWAY --env ZOSMF_HOST=your.zosmainframe.com --env ZWED_agent_host=your.zosmainframe.com --env ZOSMF_PORT=11443 --env ZWED_agent_http_port=8542 --expose ${DISCOVERY_PORT} --expose ${GATEWAY_PORT} --expose ${APP_SERVER_PORT} -p ${DISCOVERY_PORT}:${DISCOVERY_PORT} -p ${GATEWAY_PORT}:${GATEWAY_PORT} -p ${APP_SERVER_PORT}:${APP_SERVER_PORT} --env GATEWAY_PORT=${GATEWAY_PORT} --env DISCOVERY_PORT=${DISCOVERY_PORT} --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} --env EXTERNAL_CERTIFICATE=/root/zowe/ext_certs/my.keystore.p12 --env EXTERNAL_CERTIFICATE_ALIAS=alias --env EXTERNAL_CERTIFICATE_AUTHORITIES=/root/zowe/ext_certs/myCA.cer --mount type=bind,source=<folder with certs>,target=/root/zowe/ext_certs rsqa/zowe-v1-lts:s390x
+DISCOVERY_PORT=7553 GATEWAY_PORT=7554 APP_SERVER_PORT=8544 docker run -it -h your_hostname --env ZOWE_IP_ADDRESS=your.external.ip --env LAUNCH_COMPONENT_GROUPS=DESKTOP,GATEWAY --env ZOSMF_HOST=your.zosmainframe.com --env ZWED_agent_host=your.zosmainframe.com --env ZOSMF_PORT=11443 --env ZWED_agent_http_port=8542 --expose ${DISCOVERY_PORT} --expose ${GATEWAY_PORT} --expose ${APP_SERVER_PORT} -p ${DISCOVERY_PORT}:${DISCOVERY_PORT} -p ${GATEWAY_PORT}:${GATEWAY_PORT} -p ${APP_SERVER_PORT}:${APP_SERVER_PORT} --env GATEWAY_PORT=${GATEWAY_PORT} --env DISCOVERY_PORT=${DISCOVERY_PORT} --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} --env EXTERNAL_CERTIFICATE=/root/zowe/ext_certs/my.keystore.p12 --env EXTERNAL_CERTIFICATE_ALIAS=alias --env EXTERNAL_CERTIFICATE_AUTHORITIES=/root/zowe/ext_certs/myCA.cer --mount type=bind,source=<folder with certs>,target=/root/zowe/ext_certs ompzowe/zowe-v1-lts:s390x
 ```
 Note: External certificates are optional and should not be included in the start command if undesired.
 
@@ -105,7 +105,7 @@ docker run -it \
     --env DISCOVERY_PORT=${DISCOVERY_PORT} \
     --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} \
     --mount type=bind,source=c:\temp\certs,target=/root/zowe/certs \
-    rsqa/zowe-v1-lts:s390x
+    ompzowe/zowe-v1-lts:s390x
 ```
 
 #### Expected output
@@ -153,7 +153,7 @@ docker run -it \
     --env DISCOVERY_PORT=${DISCOVERY_PORT} \
     --env ZOWE_ZLUX_SERVER_HTTPS_PORT=${APP_SERVER_PORT} \
 	-v ~/apps:/root/zowe/apps:rw \
-    rsqa/zowe-v1-lts:s390x
+    ompzowe/zowe-v1-lts:s390x
 ```
 
 By default, external plugins in the ```/root/zowe/apps``` folder will be installed at start up.

--- a/dockerfiles/zowe-release/s390x/zowe-v1-lts/build.sh
+++ b/dockerfiles/zowe-release/s390x/zowe-v1-lts/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mkdir utils
 cp -r ../../../../utils/* ./utils
-docker build -f Dockerfile --no-cache -t rsqa/zowe-v1-lts:testing$1 .
+docker build -f Dockerfile --no-cache -t ompzowe/zowe-v1-lts:testing$1 .


### PR DESCRIPTION
Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

Explorer ui server - node modules are installed on z/OS - needs encoding correction.
Work around - to remove node modules install again

This is the root cause, we run `npm install --production` on z/OS just before we create pax.
https://github.com/zowe/explorer-ui-server/blob/b167e0e4698672405377d039f793015c7b7f58b0/.pax/pre-packaging.sh#L16